### PR TITLE
Delete tests/testthat/test-cpp.R

### DIFF
--- a/tests/testthat/test-cpp.R
+++ b/tests/testthat/test-cpp.R
@@ -1,2 +1,0 @@
-# Commented out to remove compile-time dependency on testthat
-# run_cpp_tests("isoband")


### PR DESCRIPTION
Doesn't do anything, and seems easy to restore later.